### PR TITLE
Disable rubocop in code climate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,3 @@
+engines:
+  rubocop:
+    enabled: false


### PR DESCRIPTION
Now that ruby 2.3 features are being used, rubocop needs to be
disabled as at the point that this commit is created there is no
support for this version of ruby.