### PR TITLE
Create a map generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 /log/*
 !/log/.keep
 /tmp
+
+# Ignore maps
+/public/maps/*

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'pg', '~> 0.15'
 gem 'bcrypt', '~> 3.1.7'
 gem 'jbuilder', '~> 2.0'
 gem 'jquery-rails'
+gem 'nokogiri'
 gem 'rubocop'
 gem 'sass-rails', '~> 5.0'
 gem 'sdoc', '~> 0.4.0', group: :doc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,6 +238,7 @@ DEPENDENCIES
   guard-rspec
   jbuilder (~> 2.0)
   jquery-rails
+  nokogiri
   pg (~> 0.15)
   rails (= 4.2.5.1)
   rspec-nc

--- a/app/assets/javascripts/worlds.js
+++ b/app/assets/javascripts/worlds.js
@@ -1,0 +1,5 @@
+$(document).ready(function () {
+  $.getJSON('/map', function (data) {
+    $('.world').attr('src', data.path)
+  });
+});

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -1,0 +1,12 @@
+# `MapsController` handles the generation of random maps
+class MapsController < ApplicationController
+  before_action :authorize_user
+
+  def show
+    map = MapGenerator.new
+    map.save
+    respond_to do |format|
+      format.json { render json: map.relative_path }
+    end
+  end
+end

--- a/app/models/map_generator.rb
+++ b/app/models/map_generator.rb
@@ -1,0 +1,86 @@
+require 'open-uri'
+
+# Access a Web Service that generates random maps
+#
+# Usage:
+#   MapGenerator.new.save
+#
+# This will create a file in public/maps/m/500x500/#{random_number}.png
+# By default, the map will be a 500x500 pixels Mercator map with a Lefebvre2
+# color map.
+class MapGenerator
+  attr_reader :seed, :width, :height, :projection, :color_map
+
+  SERVICE_HOST = 'topps.diku.dk'.freeze
+  SERVICE_PATH = '/torbenm'.freeze
+  DEFAULT_ATTRIBUTES = {
+    width: 500, height: 500, projection: 'Mercator', color_map: 'Lefebvre2'
+  }.freeze
+
+  def initialize(attributes = {})
+    initialize_attributes(attributes)
+    initialize_seed
+  end
+
+  def save
+    return true if File.exist?(full_path)
+    File.open(full_path, 'w+') { |file| file.write(File.read(open(map_url))) }
+  end
+
+  def projection_id
+    @projection_id ||= {
+      'Mercator' => 'm',
+      'Orthographic' => 'o'
+    }[projection]
+  end
+
+  def color_map_id
+    @color_map_id ||= {
+      'Lefebvre2' => 'Lefebvre2.col'
+    }[color_map]
+  end
+
+  def request_url
+    URI::HTTP.build(host: SERVICE_HOST, path: SERVICE_PATH + '/maps.msp', query: query_hash.to_query)
+  end
+
+  def map_url
+    path = Nokogiri::HTML(open(request_url)).css('img').attr('src').value
+    URI::HTTP.build(host: SERVICE_HOST, path: SERVICE_PATH + "/#{path}")
+  end
+
+  def query_hash
+    { seed: seed, width: width, height: height, projection: projection_id, colourmap: color_map_id }
+  end
+
+  def full_path
+    FileUtils.mkdir_p Rails.root.join('public', save_path)
+    @full_path ||= Rails.root.join('public', save_path, file_name)
+  end
+
+  def relative_path
+    Pathname.new("/#{save_path}/#{file_name}")
+  end
+
+  def save_path
+    Pathname("maps/#{projection_id}/#{width}x#{height}")
+  end
+
+  def file_name
+    @file_name ||= "#{seed}.png"
+  end
+
+  private
+
+  def initialize_attributes(attributes)
+    attributes.reverse_merge(DEFAULT_ATTRIBUTES).each do |attribute, value|
+      if DEFAULT_ATTRIBUTES.keys.include?(attribute)
+        instance_variable_set("@#{attribute}", value)
+      end
+    end
+  end
+
+  def initialize_seed
+    @seed = SecureRandom.random_number(99_999_999)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,5 @@ class User < ActiveRecord::Base
 
   validates :name, presence: true
   validates :email, presence: true, uniqueness: true, format: { with: /\A.+@.+\z/ }
+  validates :password, presence: true, length: { minimum: 6 }
 end

--- a/app/views/worlds/new.html.erb
+++ b/app/views/worlds/new.html.erb
@@ -5,5 +5,9 @@
 
       <%= render 'form' %>
     </div>
+
+    <div>
+      <img class="world"></img>
+    </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  resource :map, only: :show
+
   resources :locations, only: [:new, :create]
   resources :sessions, only: [:create, :destroy]
   resources :users, only: :create
@@ -7,7 +9,7 @@ Rails.application.routes.draw do
   get 'about', to: 'pages#about'
 
   constraints -> (request) { request.session[:user_id].present? } do
-    root to: 'worlds#new', as: :authenticated_root_path
+    root to: 'worlds#new', as: :authenticated_root
   end
   root to: 'pages#home'
 end

--- a/spec/models/map_generator_spec.rb
+++ b/spec/models/map_generator_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe MapGenerator, type: :model do
+  subject(:map_generator) { MapGenerator.new }
+
+  it { is_expected.to respond_to(:seed) }
+  it { is_expected.to respond_to(:width) }
+  it { is_expected.to respond_to(:height) }
+  it { is_expected.to respond_to(:projection) }
+  it { is_expected.to respond_to(:color_map) }
+
+  describe '#width' do
+    it 'returns the value of the width' do
+      expect(map_generator.width).to eq(500)
+    end
+  end
+
+  describe '#height' do
+    it 'returns the value of the height' do
+      expect(map_generator.height).to eq(500)
+    end
+  end
+
+  describe '#projection' do
+    it 'returns Mercator' do
+      expect(map_generator.projection).to eq('Mercator')
+    end
+  end
+
+  describe '#color_map' do
+    it 'returns Lefebvre2' do
+      expect(map_generator.color_map).to eq('Lefebvre2')
+    end
+  end
+
+  describe '#seed' do
+    it 'returns a random number' do
+      expect(map_generator.seed).to be_between(0, 99_999_999)
+    end
+  end
+
+  describe '#query_hash' do
+    it 'returns a hash with the query params' do
+      query_hash = {
+        width: 500,
+        height: 500,
+        projection: 'm',
+        colourmap: 'Lefebvre2.col',
+        seed: map_generator.seed
+      }
+      expect(map_generator.query_hash).to eq(query_hash)
+    end
+  end
+
+  describe '#request_url' do
+    it 'returns the url for the map service' do
+      uri = URI::HTTP.build(
+        host: 'topps.diku.dk',
+        path: '/torbenm/maps.msp',
+        query: "colourmap=Lefebvre2.col&height=500&projection=m&seed=#{map_generator.seed}&width=500"
+      )
+      expect(map_generator.request_url).to eq(uri)
+    end
+  end
+end


### PR DESCRIPTION
Use an external resource to provide a map design for the application.

Maps are generated radomly, by calling the map generator model.

Refs. #17